### PR TITLE
Send object a message instead of directly setting the attribute

### DIFF
--- a/lib/seed-fu-mongoid/document_seeder.rb
+++ b/lib/seed-fu-mongoid/document_seeder.rb
@@ -71,7 +71,7 @@ module SeedFuMongoid
 
       def seed!
         data.each do |key, value|
-          document[key] = value
+          document.send :"#{key}=", value
         end
 
         puts "#{@klass.name} #{document.attributes}"


### PR DESCRIPTION
This line will lead to fail when you have nested attributes in a document.

Since the access to the property is made directly (through the #[] method) mongoid will store the association_attributes as a property of the document, instead of triggering the nested attributes generated method.

This little patch fixes this issue.
